### PR TITLE
TCK: Don't assume every Media Type has a schema

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
+++ b/tck/src/main/java/org/eclipse/microprofile/openapi/filter/AirlinesOASFilter.java
@@ -128,7 +128,7 @@ public class AirlinesOASFilter implements OASFilter {
         if (content != null) {
             if (content.hasMediaType("application/json")) {
                 Schema schema = content.getMediaType("application/json").getSchema();
-                if ("child - id of the new review".equals(schema.getDescription())) {
+                if (schema != null && "child - id of the new review".equals(schema.getDescription())) {
                     schema.setDescription("parent - id of the new review");
                 }
             }


### PR DESCRIPTION
It's valid for a Content object, which represents the content for a Media Type, not to have a schema, so the filter TCK test should not call methods on it without checking whether it's present first.

Fixes #701